### PR TITLE
移除 router.push/replace 中的catch

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -10,14 +10,7 @@ let eventRegister = function(router) {
 
   router.push = (location, onResolve, onReject) => {
     history.action = config.pushName;
-    if (onResolve || onReject) {
-      return routerPush(location, onResolve, onReject);
-    }
-    return routerPush(location).catch(error => {
-      if (error !== undefined) {
-        console.log(error);
-      }
-    });
+    return routerPush(location, onResolve, onReject);
   };
 
   router.go = n => {
@@ -27,14 +20,7 @@ let eventRegister = function(router) {
 
   router.replace = (location, onResolve, onReject) => {
     history.action = config.replaceName;
-    if (onResolve || onReject) {
-      return routerReplace(location, onResolve, onReject);
-    }
-    return routerReplace(location).catch(error => {
-      if (error !== undefined) {
-        console.log(error);
-      }
-    });
+    return routerReplace(location, onResolve, onReject);
   };
 
   router.back = () => {


### PR DESCRIPTION
移除 router.push/replace 中的catch，因为在 vue-router v3.1 以后，使用带参数的next，永远会throw  error，详细说明可以看[这里](https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378)